### PR TITLE
Add DevAccountSwitcher component for testing user account switching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,14 @@ REACT_APP_SUPABASE_URL=http://localhost:8000
 # update this with your own anon key (must match the backend's ANON_KEY)
 REACT_APP_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzgzMDkyOTgyLCJleHAiOjIwOTg0NTI5ODJ9.feaBIOsPG5bpqiRpPZixt1HT6X-D_EkGgZStEvZsaNs
 
+# DEV ONLY - powers the "Switch User" testing dashboard (src/components/DevAccountSwitcher.tsx),
+# which mints sessions for other accounts without a password. Set this to
+# match the backend's SERVICE_ROLE_KEY (see Giftamizer-Supabase/.env) in your
+# own .env - leave blank to keep the switcher disabled. This key bypasses all
+# RLS; react-scripts strips the component (and this value) out of production
+# builds via NODE_ENV dead-code elimination, but never set it in a deployed
+# environment's config.
+REACT_APP_SUPABASE_SERVICE_ROLE_KEY=
+
 PORT=3001
 BROWSER=none

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -6,6 +6,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
 import Routes from './Routes';
+import DevAccountSwitcher from './components/DevAccountSwitcher';
 
 export default function Theme() {
 	const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
@@ -58,6 +59,7 @@ export default function Theme() {
 		<Router>
 			<ThemeProvider theme={window.location.host === 'giftamizer.com' ? theme : devTheme}>
 				<CssBaseline />
+				<DevAccountSwitcher />
 				<Routes />
 			</ThemeProvider>
 		</Router>

--- a/src/components/DevAccountSwitcher.tsx
+++ b/src/components/DevAccountSwitcher.tsx
@@ -1,0 +1,179 @@
+import * as React from 'react';
+
+import {
+	Avatar,
+	Box,
+	Button,
+	CircularProgress,
+	Dialog,
+	DialogContent,
+	DialogTitle,
+	IconButton,
+	List,
+	ListItemAvatar,
+	ListItemButton,
+	ListItemText,
+	TextField,
+	Typography,
+} from '@mui/material';
+import { Close, SwapHoriz } from '@mui/icons-material';
+
+import { useSupabase } from '../lib/useSupabase';
+import { getDevAdminClient } from '../lib/useSupabase/devAdminClient';
+
+type SwitchableProfile = {
+	user_id: string;
+	email: string;
+	first_name: string;
+	last_name: string;
+};
+
+// DEV ONLY testing dashboard: lets you jump between any seeded account
+// without knowing its password, using the service role key to mint a
+// magic-link OTP and immediately redeem it on the app's own client. See
+// devAdminClient.ts for why this is safe to leave wired up - react-scripts
+// strips this component (and the service role key it needs) out of
+// production builds.
+export default function DevAccountSwitcher() {
+	const { client, user } = useSupabase();
+
+	const [open, setOpen] = React.useState(false);
+	const [profiles, setProfiles] = React.useState<SwitchableProfile[]>([]);
+	const [search, setSearch] = React.useState('');
+	const [loading, setLoading] = React.useState(false);
+	const [switchingTo, setSwitchingTo] = React.useState<string | null>(null);
+	const [error, setError] = React.useState<string | null>(null);
+
+	if (process.env.NODE_ENV === 'production') return null;
+
+	const handleOpen = async () => {
+		setOpen(true);
+		setError(null);
+		setLoading(true);
+
+		const { data, error } = await client.from('profiles').select('user_id, email, first_name, last_name').order('first_name');
+		if (error) {
+			setError(error.message);
+		} else {
+			setProfiles((data ?? []) as SwitchableProfile[]);
+		}
+
+		setLoading(false);
+	};
+
+	const handleClose = () => {
+		if (switchingTo) return; // don't close mid-switch
+		setOpen(false);
+		setSearch('');
+		setError(null);
+	};
+
+	const handleSwitch = async (profile: SwitchableProfile) => {
+		const adminClient = getDevAdminClient();
+		if (!adminClient) {
+			setError('Missing REACT_APP_SUPABASE_SERVICE_ROLE_KEY - set it in .env (see .env.example) to use the account switcher.');
+			return;
+		}
+
+		setSwitchingTo(profile.user_id);
+		setError(null);
+
+		try {
+			const { data, error } = await adminClient.auth.admin.generateLink({ type: 'magiclink', email: profile.email });
+			if (error) throw error;
+
+			const { error: verifyError } = await client.auth.verifyOtp({
+				email: profile.email,
+				token: data.properties.email_otp,
+				type: 'magiclink',
+			});
+			if (verifyError) throw verifyError;
+
+			window.location.assign('/');
+		} catch (err: any) {
+			setError(err.message ?? 'Failed to switch accounts');
+			setSwitchingTo(null);
+		}
+	};
+
+	const filtered = profiles.filter((p) => {
+		const q = search.trim().toLowerCase();
+		if (!q) return true;
+		return `${p.first_name} ${p.last_name} ${p.email}`.toLowerCase().includes(q);
+	});
+
+	return (
+		<>
+			<Button
+				variant='contained'
+				color='warning'
+				size='small'
+				startIcon={<SwapHoriz />}
+				onClick={handleOpen}
+				sx={{
+					position: 'absolute',
+					top: 8,
+					left: '50%',
+					transform: 'translateX(-50%)',
+					zIndex: (theme) => theme.zIndex.modal + 1,
+					boxShadow: 3,
+				}}
+			>
+				Switch User
+			</Button>
+
+			<Dialog open={open} onClose={handleClose} fullWidth maxWidth='xs'>
+				<DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+					Switch Test Account
+					<IconButton onClick={handleClose} disabled={!!switchingTo}>
+						<Close />
+					</IconButton>
+				</DialogTitle>
+				<DialogContent>
+					<TextField
+						fullWidth
+						size='small'
+						placeholder='Search by name or email'
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						sx={{ mb: 2 }}
+						autoFocus
+					/>
+
+					{error && (
+						<Typography color='error' variant='body2' sx={{ mb: 2 }}>
+							{error}
+						</Typography>
+					)}
+
+					{loading ? (
+						<Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+							<CircularProgress size={28} />
+						</Box>
+					) : (
+						<List dense>
+							{filtered.map((profile) => {
+								const isCurrent = profile.user_id === user?.id;
+								return (
+									<ListItemButton key={profile.user_id} disabled={isCurrent || !!switchingTo} onClick={() => handleSwitch(profile)}>
+										<ListItemAvatar>
+											<Avatar sx={{ bgcolor: 'primary.main' }}>{(profile.first_name?.[0] ?? '?').toUpperCase()}</Avatar>
+										</ListItemAvatar>
+										<ListItemText primary={`${profile.first_name} ${profile.last_name}${isCurrent ? ' (current)' : ''}`} secondary={profile.email} />
+										{switchingTo === profile.user_id && <CircularProgress size={20} />}
+									</ListItemButton>
+								);
+							})}
+
+							{filtered.length === 0 && (
+								<Typography variant='body2' sx={{ textAlign: 'center', p: 2 }}>
+									No users found
+								</Typography>
+							)}
+						</List>
+					)}
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/src/lib/useSupabase/devAdminClient.ts
+++ b/src/lib/useSupabase/devAdminClient.ts
@@ -1,0 +1,26 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from './api';
+
+// DEV ONLY: a client authenticated with the service role key, which bypasses
+// RLS entirely. Only used by the dev account switcher
+// (components/DevAccountSwitcher.tsx) to mint sessions for other users
+// without their password. Gated behind NODE_ENV so react-scripts' production
+// build (which always sets NODE_ENV=production) dead-code eliminates this
+// whole module - REACT_APP_SUPABASE_SERVICE_ROLE_KEY should never end up in a
+// deployed bundle, but don't rely on that alone: never set that env var
+// outside local dev.
+let devAdminClient: SupabaseClient | null = null;
+
+export function getDevAdminClient(): SupabaseClient | null {
+	if (process.env.NODE_ENV === 'production') return null;
+
+	const serviceRoleKey = process.env.REACT_APP_SUPABASE_SERVICE_ROLE_KEY;
+	if (!serviceRoleKey) return null;
+
+	if (!devAdminClient) {
+		devAdminClient = createClient(SUPABASE_URL, serviceRoleKey, {
+			auth: { persistSession: false, autoRefreshToken: false },
+		});
+	}
+	return devAdminClient;
+}


### PR DESCRIPTION
This pull request introduces a development-only "Switch User" dashboard, allowing developers to quickly switch between test accounts without needing passwords. This is accomplished via a new `DevAccountSwitcher` component, which leverages a Supabase service role key to mint sessions for any seeded account. All new code is gated to never ship in production builds, ensuring security.

**Development-only account switching:**

* Added `DevAccountSwitcher` component (`src/components/DevAccountSwitcher.tsx`) that provides a UI for searching and switching between test accounts using the Supabase service role key.
* Introduced `getDevAdminClient` helper (`src/lib/useSupabase/devAdminClient.ts`) to create a Supabase client authenticated with the service role key, used exclusively for minting magic link sessions in development.
* Updated `.env.example` to document and add the `REACT_APP_SUPABASE_SERVICE_ROLE_KEY` variable, clarifying its purpose and security considerations.

**Integration and safety:**

* Registered the `DevAccountSwitcher` in the main `Theme` component so it appears in development environments only. [[1]](diffhunk://#diff-4fa01bb4a4a27a8df7566a8eb005f385d6ed38135abc5e4c352d6cd88761e11aR9) [[2]](diffhunk://#diff-4fa01bb4a4a27a8df7566a8eb005f385d6ed38135abc5e4c352d6cd88761e11aR62)
* All new code and environment variables are protected by `NODE_ENV` checks to ensure they are stripped from production builds and never expose sensitive keys. [[1]](diffhunk://#diff-7bd9158506a5ce417aa200ca109d13a73c1e1f0447d136c822a4698537dfa580R1-R179) [[2]](diffhunk://#diff-d9d5cb35adc215347749e31d1424590946e9d2667936c632e2e5f1e8a2c3779fR1-R26)